### PR TITLE
fix: include docs folder in Composer distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,6 @@
 /.gitignore         export-ignore
 /phpunit.xml.dist   export-ignore
 /art                export-ignore
-/docs               export-ignore
 /tests              export-ignore
 /workbench          export-ignore
 /.editorconfig      export-ignore


### PR DESCRIPTION
## Summary
- Remove `/docs` from `export-ignore` in `.gitattributes` so documentation files are included when the package is installed via Composer
- Fixes the "Documentation file not found" error in the `search-statamic-docs` MCP tool

## Test plan
- Install the package via Composer in a project
- Verify the `docs/` folder exists in `vendor/chrisvasey/statamic-boost/`
- Run the `search-statamic-docs` tool and verify it works