### PR TITLE
Fix Blade compilation error in guidelines by escaping Antlers syntax

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -17,38 +17,38 @@ Antlers is Statamic's templating language. Use double curly braces for variables
 
 **Variables:**
 ```antlers
-{{ title }}
-{{ content | markdown }}
-{{ date | format('F j, Y') }}
+@{{ title }}
+@{{ content | markdown }}
+@{{ date | format('F j, Y') }}
 ```
 
 **Tags (with parameters):**
 ```antlers
-{{ collection:blog limit="5" }}
+@{{ collection:blog limit="5" }}
     <article>
-        <h2>{{ title }}</h2>
-        {{ content }}
+        <h2>@{{ title }}</h2>
+        @{{ content }}
     </article>
-{{ /collection:blog }}
+@{{ /collection:blog }}
 ```
 
 **Conditionals:**
 ```antlers
-{{ if logged_in }}
-    Welcome, {{ current_user:name }}
-{{ elseif show_login }}
+@{{ if logged_in }}
+    Welcome, @{{ current_user:name }}
+@{{ elseif show_login }}
     <a href="/login">Login</a>
-{{ else }}
+@{{ else }}
     Guest content
-{{ /if }}
+@{{ /if }}
 ```
 
 **Modifiers (pipe syntax):**
 ```antlers
-{{ title | upper }}
-{{ content | markdown | safe }}
-{{ date | relative }}
-{{ image | glide:width="800" }}
+@{{ title | upper }}
+@{{ content | markdown | safe }}
+@{{ date | relative }}
+@{{ image | glide:width="800" }}
 ```
 
 ### Blueprints
@@ -171,17 +171,17 @@ GlobalSet::findByHandle('site')->in('default')->get('company_name');
 ### Tags Reference
 
 Common Antlers tags:
-- `{{ collection:* }}` - Query collection entries
-- `{{ taxonomy:* }}` - Query taxonomy terms
-- `{{ nav:* }}` - Render navigation
-- `{{ form:* }}` - Render forms
-- `{{ user:* }}` - Current user data
-- `{{ asset:* }}` - Asset information
-- `{{ glide }}` - Image manipulation
-- `{{ partial:* }}` - Include partials
-- `{{ cache }}` - Cache blocks
-- `{{ session:* }}` - Session data
-- `{{ route }}` - Generate URLs
+- `@{{ collection:* }}` - Query collection entries
+- `@{{ taxonomy:* }}` - Query taxonomy terms
+- `@{{ nav:* }}` - Render navigation
+- `@{{ form:* }}` - Render forms
+- `@{{ user:* }}` - Current user data
+- `@{{ asset:* }}` - Asset information
+- `@{{ glide }}` - Image manipulation
+- `@{{ partial:* }}` - Include partials
+- `@{{ cache }}` - Cache blocks
+- `@{{ session:* }}` - Session data
+- `@{{ route }}` - Generate URLs
 
 ### Statamic 6
 
@@ -199,6 +199,6 @@ Statamic 6 runs on Laravel 12.
 1. **Use blueprints** - Define all fields in blueprints, not inline
 2. **Leverage taxonomies** - For categories, tags, and relationships
 3. **Partial templates** - Break templates into reusable partials
-4. **Use Glide** - For responsive images: `{{ image | glide:width="800" }}`
+4. **Use Glide** - For responsive images: `@{{ image | glide:width="800" }}`
 5. **Static caching** - Enable for production sites
 6. **Git-friendly** - Commit content files for version control


### PR DESCRIPTION
## Summary

- The `core.blade.php` guideline file contains Antlers template examples using `{{ }}` syntax, which Blade's compiler interprets as PHP echo statements
- Running `boost:install --guidelines` (or `boost:install` without flags) throws a `ParseError: syntax error, unexpected identifier "limit", expecting ")"` because Blade tries to compile `{{ collection:blog limit="5" }}` as PHP
- Fixed by prefixing all `{{ }}` occurrences with `@` so Blade outputs them as literal text

## Error reproduced

```
Illuminate\View\ViewException

syntax error, unexpected identifier "limit", expecting ")"
(View: .../vendor/chrisvasey/statamic-boost/resources/boost/guidelines/core.blade.php)

➜  30▕ <?php echo e(collection:blog limit="5"); ?>
```

## Test plan

- [x] Run `php artisan boost:install --guidelines` and confirm it completes without error
- [x] Verify the generated guidelines output contains the correct Antlers syntax examples (without `@` prefix in the final output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)