### PR TITLE
fix: support laravel/mcp ^0.6

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,6 +52,7 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install dependencies
+        shell: bash
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "laravel/mcp:${{ matrix.mcp }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,6 +23,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3]
         laravel: [12.*, 11.*]
+        mcp: ["^0.5", "^0.6"]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 12.*
@@ -30,7 +31,7 @@ jobs:
           - laravel: 11.*
             testbench: 9.*
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - MCP${{ matrix.mcp }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -50,7 +51,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "laravel/mcp:${{ matrix.mcp }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,10 +22,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3]
-        laravel: [12.*, 11.*]
+        laravel: [13.*, 12.*, 11.*]
         mcp: ["^0.5", "^0.6"]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `statamic-boost` will be documented in this file.
 
+## v1.2.1 - 2026-03-26
+
+### Fixed
+
+- **laravel/mcp compatibility**: Updated `laravel/mcp` requirement from `^0.5` to `^0.5|^0.6`, unblocking installation for projects on `laravel/mcp` v0.6.x. Closes #14.
+
+### Maintenance
+
+- CI matrix now tests against `laravel/mcp` ^0.5 and ^0.6, Laravel 11/12/13, and Pest 3/4.
+
 ## v1.2.0 - 2026-03-22
 
 ### What's Changed

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     "require-dev": {
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.14",
-        "orchestra/testbench": "^10.0.0||^9.0.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0"
+        "orchestra/testbench": "^9.0.0||^10.0.0||^11.0.0",
+        "pestphp/pest": "^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.2",
         "laravel/boost": "^2.0",
-        "laravel/mcp": "^0.5",
+        "laravel/mcp": "^0.5|^0.6",
         "statamic/cms": "^5.0||^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
Widens the `laravel/mcp` constraint from `^0.5` to `^0.5|^0.6` to unblock users on `laravel/mcp` v0.6.x.

v0.6.x is a non-breaking minor release (new Image/Audio content types, localhost redirect improvements, etc.) — no changes that would affect statamic-boost.

Fixes #14.